### PR TITLE
Fix - Call to htmlspecialchars() is  is null

### DIFF
--- a/src/Odf.php
+++ b/src/Odf.php
@@ -843,7 +843,7 @@ IMG;
       return array_map([$this, 'recursiveHtmlspecialchars'], $value);
     }
     else {
-      return htmlspecialchars($value);
+      return htmlspecialchars((string) ($value ?? ''));
     }
   }
 


### PR DESCRIPTION
`htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated`